### PR TITLE
Fix compilation with gcc 7.1.1

### DIFF
--- a/butteraugli/butteraugli.cc
+++ b/butteraugli/butteraugli.cc
@@ -947,13 +947,13 @@ ImageF DiffPrecompute(const ImageF& xyb0, const ImageF& xyb1) {
         x2 = x;
       }
       double minDir =           fabs(row0_in[x] -  row0_in[x2]);
-      minDir = std::min(minDir, fabs(row0_in[x] -  row0_in2[x]));
-      minDir = std::min(minDir, fabs(row0_in[x] -  row0_in2[x2]));
-      minDir = std::min(minDir, fabs(row0_in[x2] - row0_in2[x]));
-      minDir = std::min(minDir, fabs(row1_in[x] -  row1_in[x2]));
-      minDir = std::min(minDir, fabs(row1_in[x] -  row1_in2[x]));
-      minDir = std::min(minDir, fabs(row1_in[x] -  row1_in2[x2]));
-      minDir = std::min(minDir, fabs(row1_in[x2] - row1_in2[x]));
+      minDir = std::min<double>(minDir, fabs(row0_in[x] -  row0_in2[x]));
+      minDir = std::min<double>(minDir, fabs(row0_in[x] -  row0_in2[x2]));
+      minDir = std::min<double>(minDir, fabs(row0_in[x2] - row0_in2[x]));
+      minDir = std::min<double>(minDir, fabs(row1_in[x] -  row1_in[x2]));
+      minDir = std::min<double>(minDir, fabs(row1_in[x] -  row1_in2[x]));
+      minDir = std::min<double>(minDir, fabs(row1_in[x] -  row1_in2[x2]));
+      minDir = std::min<double>(minDir, fabs(row1_in[x2] - row1_in2[x]));
       double sup0 = (fabs(row0_in[x] - row0_in[x2]) +
                      fabs(row0_in[x] - row0_in2[x]));
       double sup1 = (fabs(row1_in[x] - row1_in[x2]) +


### PR DESCRIPTION
Was "no matching function" error, specify `double` type for std::min fixes it.

Compile log:
```
butteraugli/butteraugli.cc: In function ‘pik::butteraugli::ImageF pik::butteraugli::DiffPrecompute(const ImageF&, const ImageF&)’:
butteraugli/butteraugli.cc:950:64: error: no matching function for call to ‘min(double&, float)’
       minDir = std::min(minDir, fabs(row0_in[x] -  row0_in2[x]));
                                                                ^
In file included from /usr/include/c++/7.1.1/memory:62:0,
                 from ./butteraugli/butteraugli.h:28,
                 from butteraugli/butteraugli.cc:15:
/usr/include/c++/7.1.1/bits/stl_algobase.h:195:5: note: candidate: template<class _Tp> const _Tp& std::min(const _Tp&, const _Tp&)
     min(const _Tp& __a, const _Tp& __b)
     ^~~
/usr/include/c++/7.1.1/bits/stl_algobase.h:195:5: note:   template argument deduction/substitution failed:
butteraugli/butteraugli.cc:950:64: note:   deduced conflicting types for parameter ‘const _Tp’ (‘double’ and ‘float’)
       minDir = std::min(minDir, fabs(row0_in[x] -  row0_in2[x]));
                                                                ^
In file included from /usr/include/c++/7.1.1/memory:62:0,
                 from ./butteraugli/butteraugli.h:28,
                 from butteraugli/butteraugli.cc:15:
/usr/include/c++/7.1.1/bits/stl_algobase.h:243:5: note: candidate: template<class _Tp, class _Compare> const _Tp& std::min(const _Tp&, const _Tp&, _Compare)
     min(const _Tp& __a, const _Tp& __b, _Compare __comp)
     ^~~
/usr/include/c++/7.1.1/bits/stl_algobase.h:243:5: note:   template argument deduction/substitution failed:
butteraugli/butteraugli.cc:950:64: note:   deduced conflicting types for parameter ‘const _Tp’ (‘double’ and ‘float’)
       minDir = std::min(minDir, fabs(row0_in[x] -  row0_in2[x]));
                                                                ^
In file included from /usr/include/c++/7.1.1/algorithm:62:0,
                 from butteraugli/butteraugli.cc:41:
/usr/include/c++/7.1.1/bits/stl_algo.h:3450:5: note: candidate: template<class _Tp> _Tp std::min(std::initializer_list<_Tp>)
     min(initializer_list<_Tp> __l)
     ^~~
/usr/include/c++/7.1.1/bits/stl_algo.h:3450:5: note:   template argument deduction/substitution failed:
butteraugli/butteraugli.cc:950:64: note:   mismatched types ‘std::initializer_list<_Tp>’ and ‘double’
       minDir = std::min(minDir, fabs(row0_in[x] -  row0_in2[x]));
                                                                ^
In file included from /usr/include/c++/7.1.1/algorithm:62:0,
                 from butteraugli/butteraugli.cc:41:
/usr/include/c++/7.1.1/bits/stl_algo.h:3456:5: note: candidate: template<class _Tp, class _Compare> _Tp std::min(std::initializer_list<_Tp>, _Compare)
     min(initializer_list<_Tp> __l, _Compare __comp)
     ^~~
/usr/include/c++/7.1.1/bits/stl_algo.h:3456:5: note:   template argument deduction/substitution failed:
butteraugli/butteraugli.cc:950:64: note:   mismatched types ‘std::initializer_list<_Tp>’ and ‘double’
       minDir = std::min(minDir, fabs(row0_in[x] -  row0_in2[x]));
                                                                ^
```