### PR TITLE
Fix compilation on Clang 3.4

### DIFF
--- a/bits.h
+++ b/bits.h
@@ -22,11 +22,16 @@
 // target-specific namespaces (see arch_specific.h).
 
 #ifdef __LZCNT__
-#define PIK_LZCNT32 _lzcnt_u32
-#define PIK_LZCNT64 _lzcnt_u64
+    #if PIK_COMPILER_CLANG
+        #define PIK_LZCNT32 __lzcnt32
+        #define PIK_LZCNT64 __lzcnt64
+    #else
+        #define PIK_LZCNT32 _lzcnt_u32
+        #define PIK_LZCNT64 _lzcnt_u64
+    #endif
 #else
-#define PIK_LZCNT32 NumZeroBitsAboveMSB32
-#define PIK_LZCNT64 NumZeroBitsAboveMSB64
+    #define PIK_LZCNT32 NumZeroBitsAboveMSB32
+    #define PIK_LZCNT64 NumZeroBitsAboveMSB64
 #endif
 
 #ifdef __BMI__

--- a/butteraugli/butteraugli.h
+++ b/butteraugli/butteraugli.h
@@ -120,16 +120,17 @@ bool ButteraugliAdaptiveQuantization(size_t xsize, size_t ysize,
 #define BUTTERAUGLI_INLINE inline
 #endif
 
-// Returns a void* pointer which the compiler then assumes is N-byte aligned.
-// Example: float* PIK_RESTRICT aligned = (float*)PIK_ASSUME_ALIGNED(in, 32);
-//
-// The assignment semantics are required by GCC/Clang. ICC provides an in-place
-// __assume_aligned, whereas MSVC's __assume appears unsuitable.
-#if PIK_COMPILER_GCC || PIK_COMPILER_CLANG
-#define BUTTERAUGLI_ASSUME_ALIGNED(ptr, align) \
-  __builtin_assume_aligned((ptr), (align))
+#ifdef __clang__
+  #if __has_builtin(__builtin_assume_aligned)
+    #define BUTTERAUGLI_ASSUME_ALIGNED(ptr, align) __builtin_assume_aligned((ptr), (align))
+  #else
+    // Older versions of Clang did not support __builtin_assume_aligned yet.
+    #define BUTTERAUGLI_ASSUME_ALIGNED(ptr, align) (ptr)
+  #endif
+#elif defined(__GNUC__)
+  #define BUTTERAUGLI_ASSUME_ALIGNED(ptr, align) __builtin_assume_aligned((ptr), (align))
 #else
-#define BUTTERAUGLI_ASSUME_ALIGNED(ptr, align) ptr /* not supported */
+  #define BUTTERAUGLI_ASSUME_ALIGNED(ptr, align) (ptr) /* not supported */
 #endif
 
 // Functions that depend on the cache line size.

--- a/compiler_specific.h
+++ b/compiler_specific.h
@@ -101,17 +101,17 @@
 //
 // The assignment semantics are required by GCC/Clang. ICC provides an in-place
 // __assume_aligned, whereas MSVC's __assume appears unsuitable.
-#if PIK_COMPILER_GCC
+#if PIK_COMPILER_CLANG
+  #if __has_builtin(__builtin_assume_aligned)
     #define PIK_ASSUME_ALIGNED(ptr, align) __builtin_assume_aligned((ptr), (align))
-#elif PIK_COMPILER_CLANG
-    #if __has_builtin(__builtin_assume_aligned)
-        #define PIK_ASSUME_ALIGNED(ptr, align) __builtin_assume_aligned((ptr), (align))
-    #else
-        // Early versions of Clang did not support __builtin_assume_aligned.
-        #define PIK_ASSUME_ALIGNED(ptr, align) ptr
-    #endif // __has_builtin(__builtin_assume_aligned)
+  #else
+    // Older versions of Clang did not support __builtin_assume_aligned yet.
+    #define PIK_ASSUME_ALIGNED(ptr, align) (ptr)
+  #endif
+#elif PIK_COMPILER_GCC
+  #define PIK_ASSUME_ALIGNED(ptr, align) __builtin_assume_aligned((ptr), (align))
 #else
-    #define PIK_ASSUME_ALIGNED(ptr, align) ptr /* not supported */
+  #define PIK_ASSUME_ALIGNED(ptr, align) (ptr) /* not supported */
 #endif
 
 #endif  // COMPILER_SPECIFIC_H_

--- a/dc_predictor_slow.h
+++ b/dc_predictor_slow.h
@@ -39,6 +39,8 @@ class Predictors {
  public:
   static const size_t kNum = 8;
   struct Y {
+    Y() {}
+
     PIK_INLINE void operator()(const V* const PIK_RESTRICT pos,
                                const intptr_t neg_col_stride,
                                const intptr_t neg_row_stride,
@@ -59,6 +61,8 @@ class Predictors {
   };
 
   struct UV {
+    UV() {}
+
     PIK_INLINE void operator()(const V* const PIK_RESTRICT pos,
                                const intptr_t neg_col_stride,
                                const intptr_t neg_row_stride,


### PR DESCRIPTION
Fixes #25.

All of these preprocessor defines are a bit ugly, but for now this at least makes it compile.